### PR TITLE
Fixed Template Injection false positive

### DIFF
--- a/core/scanner.py
+++ b/core/scanner.py
@@ -336,21 +336,21 @@ class paramscanner: # Scanner Module
 				ok = True
 		if ok:
 			x = 0
-			payloads=['{{6*6}}','<%= 6 * 6 %>','${6*6}']
+			payloads=['test{{6*6}}purpose','test<%= 6 * 6 %>purpose','test${6*6}purpose']
 			for payload in payloads:
 				for i,c in dat.items():
 					dat[i] = c.replace('*','Scant3rSSTI')
 				te = requests.post(url,data=dat,headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
 				sleep(slp)
-				fir = re.findall('36'.encode('utf-8'),te.content)
+				fir = re.findall('test36purpose'.encode('utf-8'),te.content)
 				for i,c in dat.items():
 					dat[i] = c.replace('Scant3rSSTI',payload)
 				sleep(slp)
 				r = requests.post(url,data=dat,headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-				ch = re.findall('36'.encode('utf-8'),r.content)
+				ch = re.findall('test36purpose'.encode('utf-8'),r.content)
 				if len(ch) > len(fir):
 					r = requests.post(url,data=dat,headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-					ch = re.findall('36'.encode('utf-8'),r.content)
+					ch = re.findall('test36purpose'.encode('utf-8'),r.content)
 					print(f"""
 \033[91m#{yellow}{bold}--------------------------------{end}\033[91m#{end}
 {bold}{good}{bold} Bug Found : Template injection (SSTI)
@@ -367,17 +367,17 @@ class paramscanner: # Scanner Module
 						dat[i] = i.replace(payload,'*')
 					continue
 		else:
-			payloads=['{{6*6}}','<%= 6 * 6 %>','${6*6}']
+			payloads=['test{{6*6}}purpose','test<%= 6 * 6 %>purpose','test${6*6}purpose']
 			x = 0
 			sleep(slp)
 			te = requests.post(url,data=dat,headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-			fir = re.findall('36'.encode('utf-8'),te.content)
+			fir = re.findall('test36purpose'.encode('utf-8'),te.content)
 			for payload in payloads:
 				for i,c in dat.items():
 					dat[i] = c + payload
 				sleep(slp)
 				r = requests.post(url,data=dat,headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-				ch = re.findall('36'.encode('utf-8'),r.content)
+				ch = re.findall('test36purpose'.encode('utf-8'),r.content)
 				if len(ch) > len(fir):
 					print(f"""
 \033[91m#{yellow}{bold}--------------------------------{end}\033[91m#{end}
@@ -486,16 +486,16 @@ class paramscanner: # Scanner Module
 	def ssti(self,url,co,tim,deco,redir,cagent=None,proxy=None,slp=0,batch=None):
 		if '*' in url:
 			x = 0
-			payloads=['{{ 6*6 }}','<%= 6 * 6 %>','${6*6}']
+			payloads=['test{{6*6}}purpose','test<%= 6 * 6 %>purpose','test${6*6}purpose']
 			sleep(slp)
 			te=requests.get(url.replace('*',''),headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-			fir = re.findall('36'.encode('utf-8'),te.content)
+			fir = re.findall('test36purpose'.encode('utf-8'),te.content)
 			for payload in payloads:
 				for h in range(deco):
 					payload=urlencoder(payload)
 				sleep(slp)
 				r=requests.get(url.replace('*',str(payload).strip()),headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-				ch = re.findall('36'.encode('utf-8'),r.content)
+				ch = re.findall('test36purpose'.encode('utf-8'),r.content)
 				if len(ch) > len(fir):
 					j=url.replace('*',str(payload).strip())
 					print (f"""
@@ -509,15 +509,15 @@ class paramscanner: # Scanner Module
 			sleep(slp)
 			x = 0
 			te=requests.get(url,headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-			fir = re.findall('36'.encode('utf-8'),te.content)
+			fir = re.findall('test36purpose'.encode('utf-8'),te.content)
 			for params in url.split("?")[1].split("&"):
-				payloads=['{{6*6}}','<%= 6 * 6 %>','${6*6}']
+				payloads=['test{{6*6}}purpose','test<%= 6 * 6 %>purpose','test${6*6}purpose']
 				for payload in payloads:
 					for h in range(deco):
 						payload=urlencoder(payload)
 					sleep(slp)
 					r=requests.get(url.replace(params, params + str(payload).strip()),headers={'User-agent':uagent(cagent=cagent)},cookies=co,verify=False,allow_redirects=redir,timeout=tim,proxies=proxy)
-					ch = re.findall('36'.encode('utf-8'),r.content)
+					ch = re.findall('test36purpose'.encode('utf-8'),r.content)
 					if len(ch) > len(fir):
 						j=url.replace(params, params + str(payload).strip())
 						print (f"""
@@ -685,7 +685,7 @@ class headers_scanner: # Header Scanner Module ;-;
 {bold}{info}{bold} URL : {r.url}{end}
 \033[91m#{yellow}{bold}--------------------------------{end}\033[91m#{end}""")
 	def referrer_ssti(url,timeo=None,cookie=None,redir=None,deco=None,method=None,date=None,cagent=None,proxy=None,slp=0,batch=None):
-		payloads=['{{ 6*6 }}','<%= 6 * 6 %>','${6*6}']
+		payloads=['test{{6*6}}purpose','test<%= 6 * 6 %>purpose','test${6*6}purpose']
 		for payload in payloads:
 			if method == 'get':
  				sleep(slp)
@@ -696,10 +696,10 @@ class headers_scanner: # Header Scanner Module ;-;
  				r = requests.get(url,headers={"User-agent":uagent(cagent=cagent),"referrer":f"{payload}"},timeout=timeo,verify=False,allow_redirects=redir,cookies=cookie,proxies=proxy)
  				sleep(slp)
  				r2 = requests.post(url,headers={"User-agent":uagent(cagent=cagent),"referrer":f"{payload}"},timeout=timeo,verify=False,allow_redirects=redir,cookies=cookie,proxies=proxy)
- 				cch = re.findall("36".encode('utf-8'),rr.content)
- 				cch2 = re.findall("36".encode("utf-8"),rr2.content)
- 				ch = re.findall('36'.encode('utf-8'),r.content)
- 				ch2 = re.findall("36".encode("utf-8"),r2.content)
+ 				cch = re.findall("test36purpose".encode('utf-8'),rr.content)
+ 				cch2 = re.findall("test36purpose".encode("utf-8"),rr2.content)
+ 				ch = re.findall('test36purpose'.encode('utf-8'),r.content)
+ 				ch2 = re.findall("test36purpose".encode("utf-8"),r2.content)
  				if len(ch) > len(cch):
  					print (f"""
 \033[91m#{yellow}{bold}--------------------------------{end}\033[91m#{end}


### PR DESCRIPTION
The Template Injection check only scans for the word `36` in the response. There is a high possibility for this number to be present in any of the response body and hence the scanner flags it incorrectly. Modified the string to include additional characters and only scan for a valid vector. 