### PR TITLE
fix: fixed windows prompt colors

### DIFF
--- a/scant3r.py
+++ b/scant3r.py
@@ -3,10 +3,15 @@
 __author__ = 'Khaled Nassar'
 __email__ = 'knassar702@gmail.com'
 __version__ = '0.6#Beta'
+
 import sys
 if sys.version_info < (3, 6):
     print('[-] Scant3r requires python >= 3.6')
     sys.exit()
+
+import colorama
+colorama.init()
+
 from optparse import OptionParser
 from libs import NewRequest as nq
 from libs import extractHeaders,post_data,dump_alloptions


### PR DESCRIPTION
On windows prompt, the colors doesn't get printed correctly.
![image](https://user-images.githubusercontent.com/50470310/106415608-4727dc80-642e-11eb-9f9a-17f6de011621.png)

<br>

But if we put colorama init. the colors works perfectly.
![image](https://user-images.githubusercontent.com/50470310/106415651-632b7e00-642e-11eb-9df2-465fe736f3db.png)

*I have tested colorama init on Ubuntu and doesn't have any colors conflict.*

Best regards,
oppsec.

